### PR TITLE
odfdom-java versio 0.8.5 no longer exists in maven central

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -25,7 +25,7 @@ grails.project.dependency.resolution = {
         compile 'com.lowagie:itext:2.1.7'
         compile("com.lowagie:itext-rtf:2.1.7")
         runtime 'xerces:xercesImpl:2.9.0'
-        compile 'org.odftoolkit:odfdom-java:0.8.5'
+        compile 'org.odftoolkit:odfdom-java:0.8.7'
         compile 'net.sourceforge.jexcelapi:jxl:2.6.12'
         compile 'commons-beanutils:commons-beanutils:1.8.3'
     }


### PR DESCRIPTION
Fixes so this plugin can resolve dependencies