### PR TITLE
Xml first node name

### DIFF
--- a/src/main/groovy/grails/plugins/export/exporter/DefaultXMLExporter.groovy
+++ b/src/main/groovy/grails/plugins/export/exporter/DefaultXMLExporter.groovy
@@ -57,12 +57,20 @@ class DefaultXMLExporter extends AbstractExporter {
 	
 	private void build(String node, builder, Collection data, List fields, int depth){
 		if(depth >= 0 && data.size() > 0){
+			// Check to use id as node attribute
+			def attributeMap
+			if(getParameters().containsKey("xml.hide.id.attribute")){
+				if(getParameters().get("xml.hide.id.attribute")){
+					attributeMap = [:]
+				}
+			}
+
 			//Root element
 			builder."${properCase(node)}"{
 				//Iterate through data
 				data.each { object ->
 					//Object element
-					"${properCase(object?.getClass()?.simpleName)}"(id: object?.id){
+					"${properCase(object?.getClass()?.simpleName)}"(attributeMap != null ? attributeMap : [id: object?.id]){
 						//Object attributes
 						fields.each { field ->
 							String elementName = getLabel(field)

--- a/src/main/groovy/grails/plugins/export/exporter/DefaultXMLExporter.groovy
+++ b/src/main/groovy/grails/plugins/export/exporter/DefaultXMLExporter.groovy
@@ -70,7 +70,7 @@ class DefaultXMLExporter extends AbstractExporter {
 				//Iterate through data
 				data.each { object ->
 					//Object element
-					"${properCase(object?.getClass()?.simpleName)}"(attributeMap != null ? attributeMap : [id: object?.id]){
+					"${object?.xmlNodeName ?: properCase(object?.getClass()?.simpleName)}"(attributeMap != null ? attributeMap : [id: object?.id]){
 						//Object attributes
 						fields.each { field ->
 							String elementName = getLabel(field)


### PR DESCRIPTION
Added additional parameter for XML generation: xml.hide.id.attribute.
If set true, then the XML generation omits adding the id attribute in the node.

Added the possibility to specify the node name if an array of hash maps is used. The key should be xmlNodeName.

An example of this is: 

```groovy
def list = []
list.add([
    'id': 1,
    'name': 'John',
    'xmlNodeName': 'user'
])
```

Without taking into account the 2 changes made, the result of the defined list would be:

```xml
<linkedHashMaps>
    <linkedHashMap id='1'>
        <id>1</Id>
        <name>John</name>
    </linkedHashMap>
</linkedHashMaps>
``` 

By defining the xml.root parameter as "users", xml.hide.id.attribute as true and setting a xmlNodeName value the final result will be:

```xml
<users>
    <user>
        <id>1</Id>
        <name>John</name>
    </user>
</users>
``` 